### PR TITLE
Added support for additional frame rates (50fps and 25fps).

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -36,7 +36,9 @@
   <label for="limitfps">Limit FPS</label>
   <select id="limitfps">
     <option id="limitfps0" value="0">No limit</option>
+    <option id="limitfps50" value="50">50FPS</option>
     <option id="limitfps30" value="30">30FPS</option>
+    <option id="limitfps25" value="25">25FPS</option>
     <option id="limitfps10" value="10">10FPS</option>
     <option id="limitfps2" value="2">2FPS</option>
   </select>


### PR DESCRIPTION
I'm trying to use the Chromium framework (via [CEF](https://bitbucket.org/chromiumembedded/cef/src)) to render HTML content and composite it over video. Similar things are done with OBS Studio and Caspar CG.

In the video world, it's common to have frame rates of 50fps and 25fps. As such, it would be nice to be able to use FPS control via Chrome to preview content at 50/25fps for how it may appear in the realms of these third-party applications.

****Note**: I think I've made the correct & necessary code changes, but I am a mere novice in the realms of HTML/CSS.